### PR TITLE
Initial editor through "Edit as Code" post menu action

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "monaco-editor",
     "name": "Monaco Editor",
-    "description": "Edit code inside of Mattermost.",
+    "description": "Edit code inside of Mattermost!",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-starter-template",
     "support_url": "https://github.com/mattermost/mattermost-plugin-starter-template/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-starter-template/releases/tag/v0.1.0",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
-    "id": "com.mattermost.plugin-starter-template",
-    "name": "Plugin Starter Template",
-    "description": "This plugin serves as a starting point for writing a Mattermost plugin.",
+    "id": "monaco-editor",
+    "name": "Monaco Editor",
+    "description": "Edit code inside of Mattermost.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-starter-template",
     "support_url": "https://github.com/mattermost/mattermost-plugin-starter-template/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-starter-template/releases/tag/v0.1.0",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -12,9 +12,13 @@ var manifest *model.Manifest
 
 const manifestStr = `
 {
-  "id": "com.mattermost.plugin-starter-template",
-  "name": "Plugin Starter Template",
-  "description": "This plugin serves as a starting point for writing a Mattermost plugin.",
+  "id": "monaco-editor",
+  "name": "Monaco Editor",
+  "description": "Edit code inside of Mattermost.",
+  "homepage_url": "https://github.com/mattermost/mattermost-plugin-starter-template",
+  "support_url": "https://github.com/mattermost/mattermost-plugin-starter-template/issues",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-starter-template/releases/tag/v0.1.0",
+  "icon_path": "assets/starter-template-icon.svg",
   "version": "0.1.0",
   "min_server_version": "5.12.0",
   "server": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -14,7 +14,7 @@ const manifestStr = `
 {
   "id": "monaco-editor",
   "name": "Monaco Editor",
-  "description": "Edit code inside of Mattermost.",
+  "description": "Edit code inside of Mattermost!",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-starter-template",
   "support_url": "https://github.com/mattermost/mattermost-plugin-starter-template/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-starter-template/releases/tag/v0.1.0",

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/mattermost/mattermost-server/v5/plugin"
@@ -22,7 +23,17 @@ type Plugin struct {
 
 // ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/vs") {
+		serveVs(c, w, r)
+		return
+	}
 	fmt.Fprint(w, "Hello, world!")
 }
 
 // See https://developers.mattermost.com/extend/plugins/server/reference/
+
+func serveVs(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+	dir := "/Users/koch/go/src/github.com/mattermost/mattermost-plugin-monaco/webapp/node_modules/monaco-editor/min"
+	p := dir + r.URL.Path
+	http.ServeFile(w, r, p)
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/mattermost/mattermost-server/v5/plugin"
@@ -23,17 +22,7 @@ type Plugin struct {
 
 // ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	if strings.HasPrefix(r.URL.Path, "/vs") {
-		serveVs(c, w, r)
-		return
-	}
 	fmt.Fprint(w, "Hello, world!")
 }
 
 // See https://developers.mattermost.com/extend/plugins/server/reference/
-
-func serveVs(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	dir := "/Users/koch/go/src/github.com/mattermost/mattermost-plugin-monaco/webapp/node_modules/monaco-editor/min"
-	p := dir + r.URL.Path
-	http.ServeFile(w, r, p)
-}

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -3822,6 +3822,36 @@
         }
       }
     },
+    "@monaco-editor/loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.0.1.tgz",
+      "integrity": "sha512-hycGOhLqLYjnD0A/FHs56covEQWnDFrSnm/qLKkB/yoeayQ7ju+Vaj4SdTojGrXeY6jhMDx59map0+Jqwquh1Q==",
+      "requires": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "@monaco-editor/react": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.1.0.tgz",
+      "integrity": "sha512-Hh895v/KfGgckDLXq8sdDGT4xS89+2hbQOP1l57sLd2XlJycChdzPiCj02nQDIduLmUIVHittjaj1/xmy94C3A==",
+      "requires": {
+        "@monaco-editor/loader": "^1.0.1",
+        "prop-types": "^15.7.2",
+        "state-local": "^1.0.7"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
     "@popmotion/easing": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
@@ -13755,6 +13785,11 @@
         "moment": ">= 2.9.0"
       }
     },
+    "monaco-editor": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.23.0.tgz",
+      "integrity": "sha512-q+CP5zMR/aFiMTE9QlIavGyGicKnG2v/H8qVvybLzeFsARM8f6G9fL0sMST2tyVYCwDKkGamZUI6647A0jR/Lg=="
+    },
     "moo": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
@@ -16988,6 +17023,11 @@
           "dev": true
         }
       }
+    },
+    "state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -63,8 +63,10 @@
     "webpack-cli": "3.3.12"
   },
   "dependencies": {
+    "@monaco-editor/react": "4.1.0",
     "core-js": "3.6.5",
     "mattermost-redux": "5.27.0",
+    "monaco-editor": "0.23.0",
     "react": "16.13.1",
     "react-redux": "7.2.0",
     "redux": "4.0.5",

--- a/webapp/src/editor.tsx
+++ b/webapp/src/editor.tsx
@@ -41,8 +41,8 @@ const Editor: React.FC<EditorProps> = ({post, close}: EditorProps) => {
         <div>
             <div style={{
                 paddingTop: '35px',
-                paddingLeft: '28%',
-                paddingRight: '28%',
+                paddingLeft: '25%',
+                paddingRight: '25%',
             }}>
                 <div style={{marginBottom: '10px'}}>
                     <button

--- a/webapp/src/editor.tsx
+++ b/webapp/src/editor.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {Post} from 'mattermost-redux/types/posts';
+import {editPost} from 'mattermost-redux/actions/posts';
+import {useDispatch} from 'react-redux';
+
+import MonacoEditor from '@monaco-editor/react';
+
+type EditorProps = {
+    post: Post;
+    close: () => void;
+}
+
+const Editor: React.FC<EditorProps> = ({post, close}: EditorProps) => {
+    const [text, setText] = React.useState<string>(post.message);
+
+    const dispatch = useDispatch();
+    const savePost = () => {
+        const postToSave = {
+            ...post,
+            message: text,
+        };
+        dispatch(editPost(postToSave));
+        close();
+    }
+
+    const onChange = (text = '') => {
+        setText(text);
+    }
+
+    const [theme, setTheme] = React.useState('vs-dark');
+
+    const toggleTheme = () => {
+        const newTheme = theme === 'vs-dark' ? 'light' : 'vs-dark';
+        setTheme(newTheme);
+    }
+
+    return (
+        <div>
+            <div style={{
+                paddingTop: '35px',
+                paddingLeft: '28%',
+                paddingRight: '28%',
+            }}>
+                <div style={{marginBottom: '10px'}}>
+                    <button
+                        type='button'
+                        className={'btn btn-danger'}
+                        onClick={close}
+                    >
+                        {'Cancel'}
+                    </button>
+                    <button
+                        type='button'
+                        className={'btn btn-primary'}
+                        onClick={toggleTheme}
+                    >
+                        {'Toggle Theme'}
+                    </button>
+                    <button
+                        type='button'
+                        className={'btn btn-primary'}
+                        onClick={savePost}
+                    >
+                        {'Save'}
+                    </button>
+                </div>
+
+                <MonacoEditor
+                    height='90vh'
+                    defaultLanguage='markdown'
+                    value={text}
+                    onChange={onChange}
+                    theme={theme}
+                />
+            </div>
+        </div>
+    );
+}
+
+export default Editor;

--- a/webapp/src/editor.tsx
+++ b/webapp/src/editor.tsx
@@ -3,6 +3,9 @@ import {Post} from 'mattermost-redux/types/posts';
 import {editPost} from 'mattermost-redux/actions/posts';
 import {useDispatch} from 'react-redux';
 
+import config from '@monaco-editor/loader/lib/es/config';
+config.paths.vs = '/plugins/monaco-editor/public/vs';
+
 import MonacoEditor from '@monaco-editor/react';
 
 type EditorProps = {

--- a/webapp/src/full_screen_modal/back_icon.tsx
+++ b/webapp/src/full_screen_modal/back_icon.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+type Props = {
+    className?: string;
+}
+
+export default class BackIcon extends React.PureComponent<Props> {
+    render(): JSX.Element {
+        return (
+            <button
+                {...this.props}
+            >
+                <FormattedMessage
+                    id='generic_icons.back'
+                    defaultMessage='Back Icon'
+                >
+                    {(ariaLabel: string): JSX.Element => (
+                        <svg
+                            width='24px'
+                            height='24px'
+                            viewBox='0 0 24 24'
+                            role='icon'
+                            aria-label={ariaLabel}
+                        >
+                            <path d='M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z'/>
+                        </svg>
+                    )}
+                </FormattedMessage>
+            </button>
+        );
+    }
+}

--- a/webapp/src/full_screen_modal/close_icon.tsx
+++ b/webapp/src/full_screen_modal/close_icon.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+type Props = {
+    className?: string;
+}
+
+export default class CloseIcon extends React.PureComponent<Props> {
+    render(): JSX.Element {
+        return (
+            <button
+                {...this.props}
+            >
+                <FormattedMessage
+                    id='generic_icons.close'
+                    defaultMessage='Close Icon'
+                >
+                    {(ariaLabel: string): JSX.Element => (
+                        <svg
+                            width='24px'
+                            height='24px'
+                            viewBox='0 0 24 24'
+                            role='icon'
+                            aria-label={ariaLabel}
+                        >
+                            <path d='M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z'/>
+                        </svg>
+                    )}
+                </FormattedMessage>
+            </button>
+        );
+    }
+}

--- a/webapp/src/full_screen_modal/full_screen_modal.jsx
+++ b/webapp/src/full_screen_modal/full_screen_modal.jsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {CSSTransition} from 'react-transition-group';
+
+import CloseIcon from './close_icon';
+
+// This must be on sync with the animation time in ./full_screen_modal.scss
+const ANIMATION_DURATION = 100;
+
+export default class FullScreenModal extends React.Component {
+    static propTypes = {
+        show: PropTypes.bool.isRequired,
+        children: PropTypes.node.isRequired,
+        onClose: PropTypes.func.isRequired,
+    }
+
+    componentDidMount() {
+        document.addEventListener('keydown', this.handleKeypress);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeypress);
+    }
+
+    handleKeypress = (e) => {
+        if (e.key === 'Escape' && this.props.show) {
+            this.close();
+        }
+    }
+
+    close = () => {
+        this.props.onClose();
+    }
+
+    render() {
+        return (
+            <CSSTransition
+                in={this.props.show}
+                classNames='FullScreenModal'
+                mountOnEnter={true}
+                unmountOnExit={true}
+                timeout={ANIMATION_DURATION}
+                appear={true}
+            >
+                <div className='FullScreenModal FullScreenModal--compact'>
+                    <CloseIcon
+                        className='close-x'
+                        onClick={this.close}
+                    />
+                    {this.props.children}
+                </div>
+            </CSSTransition>
+        );
+    }
+}

--- a/webapp/src/full_screen_modal/full_screen_modal.test.jsx
+++ b/webapp/src/full_screen_modal/full_screen_modal.test.jsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import CloseIcon from './close_icon';
+
+import FullScreenModal from './full_screen_modal.jsx';
+
+describe('components/widgets/modals/FullScreenModal', () => {
+    test('showing content', () => {
+        const wrapper = shallow(
+            <FullScreenModal
+                show={true}
+                onClose={jest.fn()}
+            >
+                {'test'}
+            </FullScreenModal>
+        );
+        expect(wrapper).toMatchInlineSnapshot(`
+<CSSTransition
+  appear={true}
+  classNames="FullScreenModal"
+  in={true}
+  mountOnEnter={true}
+  timeout={100}
+  unmountOnExit={true}
+>
+  <div
+    className="FullScreenModal FullScreenModal--compact"
+  >
+    <CloseIcon
+      className="close-x"
+      onClick={[Function]}
+    />
+    test
+  </div>
+</CSSTransition>
+`);
+    });
+    test('not showing content', () => {
+        const wrapper = shallow(
+            <FullScreenModal
+                show={false}
+                onClose={jest.fn()}
+            >
+                {'test'}
+            </FullScreenModal>
+        );
+        expect(wrapper).toMatchInlineSnapshot(`
+<CSSTransition
+  appear={true}
+  classNames="FullScreenModal"
+  in={false}
+  mountOnEnter={true}
+  timeout={100}
+  unmountOnExit={true}
+>
+  <div
+    className="FullScreenModal FullScreenModal--compact"
+  >
+    <CloseIcon
+      className="close-x"
+      onClick={[Function]}
+    />
+    test
+  </div>
+</CSSTransition>
+`);
+    });
+    test('close on close icon click', () => {
+        const close = jest.fn();
+        const wrapper = shallow(
+            <FullScreenModal
+                show={true}
+                onClose={close}
+            >
+                {'test'}
+            </FullScreenModal>
+        );
+        expect(close).not.toBeCalled();
+        wrapper.find(CloseIcon).simulate('click');
+        expect(close).toBeCalled();
+    });
+
+    test('close on esc keypress', () => {
+        const close = jest.fn();
+        shallow(
+            <FullScreenModal
+                show={true}
+                onClose={close}
+            >
+                {'test'}
+            </FullScreenModal>
+        );
+        expect(close).not.toBeCalled();
+        const event = new KeyboardEvent('keydown', {key: 'Escape'});
+        document.dispatchEvent(event);
+        expect(close).toBeCalled();
+    });
+});

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1,16 +1,33 @@
+import React from 'react';
 import {Store, Action} from 'redux';
 
 import {GlobalState} from 'mattermost-redux/types/store';
+import {Post} from 'mattermost-redux/types/posts';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 import manifest from './manifest';
 
 // eslint-disable-next-line import/no-unresolved
 import {PluginRegistry} from './types/mattermost-webapp';
 
+// import 'monaco-editor/min/vs/loader';
+import MonacoEditor from '@monaco-editor/react';
+
+import './monaco.scss';
+import FullScreenModal from './full_screen_modal/full_screen_modal';
+
 export default class Plugin {
+    setActivePost = (post: Post) => {};
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    public async initialize(registry: PluginRegistry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
+    public async initialize(registry: PluginRegistry | any, store: Store<GlobalState, Action<Record<string, unknown>>>) {
         // @see https://developers.mattermost.com/extend/plugins/webapp/reference/
+        registry.registerRootComponent(Editor);
+
+        registry.registerPostDropdownMenuAction('Edit as code', (postID: string) => {
+            const post = getPost(store.getState(), postID);
+            this.setActivePost(post);
+        }, () => true);
     }
 }
 
@@ -20,4 +37,42 @@ declare global {
     }
 }
 
-window.registerPlugin(manifest.id, new Plugin());
+const p = new Plugin();
+
+window.registerPlugin(manifest.id, p);
+
+const Editor: React.FC = () => {
+    const [activePost, setActivePost] = React.useState<Post | null>(null);
+    p.setActivePost = setActivePost;
+
+    const [theme, setTheme] = React.useState('vs-dark');
+
+    const toggleTheme = () => {
+        const newTheme = theme === 'vs-dark' ? 'light' : 'vs-dark';
+        setTheme(newTheme);
+    }
+
+    const close = () => setActivePost(null);
+    return (
+        <FullScreenModal
+            show={Boolean(activePost)}
+            onClose={close}
+        >
+            <div>
+                {/* <button onClick={toggleTheme}>{'Toggle Theme'}</button> */}
+                <div style={{
+                    paddingTop: '45px',
+                    paddingLeft: '28%',
+                    paddingRight: '28%',
+                }}>
+                    <MonacoEditor
+                        height='90vh'
+                        defaultLanguage='markdown'
+                        defaultValue={activePost?.message || ''}
+                        theme={theme}
+                    />
+                </div>
+            </div>
+        </FullScreenModal>
+    );
+}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -4,17 +4,27 @@ import {Store, Action} from 'redux';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {Post} from 'mattermost-redux/types/posts';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {canEditPost} from 'mattermost-redux/utils/post_utils';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import manifest from './manifest';
 
 // eslint-disable-next-line import/no-unresolved
 import {PluginRegistry} from './types/mattermost-webapp';
 
-// import 'monaco-editor/min/vs/loader';
-import MonacoEditor from '@monaco-editor/react';
-
-import './monaco.scss';
 import FullScreenModal from './full_screen_modal/full_screen_modal';
+import Editor from './editor';
+
+const canEdit = (state: GlobalState, post: Post): boolean => {
+    const config = state.entities.general.config;
+    const license = state.entities.general.license;
+    const userId = getCurrentUserId(state);
+    const channel = getChannel(state, post.channel_id);
+    const teamId = channel.team_id || '';
+
+    return canEditPost(state, config, license, teamId, post.channel_id, userId, post);
+}
 
 export default class Plugin {
     setActivePost = (post: Post) => {};
@@ -22,12 +32,23 @@ export default class Plugin {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     public async initialize(registry: PluginRegistry | any, store: Store<GlobalState, Action<Record<string, unknown>>>) {
         // @see https://developers.mattermost.com/extend/plugins/webapp/reference/
-        registry.registerRootComponent(Editor);
+        registry.registerRootComponent(EditorModal);
 
         registry.registerPostDropdownMenuAction('Edit as code', (postID: string) => {
             const post = getPost(store.getState(), postID);
             this.setActivePost(post);
-        }, () => true);
+        }, (postID: string) => {
+            if (!postID) {
+                return false;
+            }
+            const state = store.getState();
+            const post = getPost(state, postID);
+            if (!post) {
+                return false;
+            }
+
+            return canEdit(state, post);
+        });
     }
 }
 
@@ -41,15 +62,12 @@ const p = new Plugin();
 
 window.registerPlugin(manifest.id, p);
 
-const Editor: React.FC = () => {
+const EditorModal: React.FC = () => {
     const [activePost, setActivePost] = React.useState<Post | null>(null);
     p.setActivePost = setActivePost;
 
-    const [theme, setTheme] = React.useState('vs-dark');
-
-    const toggleTheme = () => {
-        const newTheme = theme === 'vs-dark' ? 'light' : 'vs-dark';
-        setTheme(newTheme);
+    if (!activePost) {
+        return null;
     }
 
     const close = () => setActivePost(null);
@@ -58,21 +76,10 @@ const Editor: React.FC = () => {
             show={Boolean(activePost)}
             onClose={close}
         >
-            <div>
-                {/* <button onClick={toggleTheme}>{'Toggle Theme'}</button> */}
-                <div style={{
-                    paddingTop: '45px',
-                    paddingLeft: '28%',
-                    paddingRight: '28%',
-                }}>
-                    <MonacoEditor
-                        height='90vh'
-                        defaultLanguage='markdown'
-                        defaultValue={activePost?.message || ''}
-                        theme={theme}
-                    />
-                </div>
-            </div>
+            <Editor
+                post={activePost}
+                close={close}
+            />
         </FullScreenModal>
     );
-}
+};


### PR DESCRIPTION
This plugin uses https://github.com/suren-atoyan/monaco-react to implement the Monaco editor, accessible through a post menu action showing "Edit as Code".

Monaco editor files that are fetched asynchronously are being served out of the plugin's public folder. These could be proxied form the plugin's server to CDN instead, but I wanted to keep the plugin self-contained. Those were added in a commit before this PR to keep this PR small.